### PR TITLE
Correct spelling mistake

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -731,7 +731,7 @@
 		"legacy_username": "Has legacy username",
 		"quest_completed": "did a quest"
 	},
-	"dms":"Dirrect Messages",
+	"dms":"Direct Messages",
 	"group":{
 		"select":"Select Friends",
 		"createdm":"Create DM!",


### PR DESCRIPTION
"Dirrect" seems to be a typo. Changed it to "Direct" which is the correct spelling.
