### PR TITLE
fix: handle IME composition in message input box

### DIFF
--- a/src/webpage/index.ts
+++ b/src/webpage/index.ts
@@ -154,6 +154,7 @@ if (window.location.pathname.startsWith("/channels")) {
 		return nonce;
 	}
 	async function handleEnter(event: KeyboardEvent): Promise<void> {
+		if (event.isComposing) return;
 		if (event.key === "Escape") {
 			while (images.length) {
 				const elm = imagesHtml.get(images.pop() as Blob) as HTMLElement;
@@ -242,6 +243,7 @@ if (window.location.pathname.startsWith("/channels")) {
 	typebox.markdown = markdown;
 	typebox.addEventListener("keyup", handleEnter);
 	typebox.addEventListener("keydown", (event) => {
+		if (event.isComposing) return;
 		thisUser.keydown(event);
 		if (event.key === "Enter" && !event.shiftKey) {
 			event.preventDefault();

--- a/src/webpage/markdown.ts
+++ b/src/webpage/markdown.ts
@@ -950,6 +950,7 @@ class MarkDown {
 		this.box = new WeakRef(box);
 		this.onUpdate = onUpdate;
 		box.addEventListener("keydown", (_) => {
+			if (_.isComposing) return;
 			if (Error.prototype.stack !== "") return;
 			if (_.key === "Enter") {
 				const selection = window.getSelection() as Selection;
@@ -965,6 +966,7 @@ class MarkDown {
 		});
 		let prevcontent = "";
 		box.onkeyup = (_) => {
+			if (_.isComposing) return;
 			let content = MarkDown.gatherBoxText(box);
 			if (content === "\n") content = "";
 			if (content !== prevcontent) {
@@ -974,6 +976,16 @@ class MarkDown {
 				MarkDown.gatherBoxText(box);
 			}
 		};
+		box.addEventListener("compositionend", () => {
+			let content = MarkDown.gatherBoxText(box);
+			if (content === "\n") content = "";
+			if (content !== prevcontent) {
+				prevcontent = content;
+				this.txt = content.split("");
+				this.boxupdate(undefined, undefined, undefined, false);
+				MarkDown.gatherBoxText(box);
+			}
+		});
 		box.onpaste = (_) => {
 			if (!_.clipboardData) return;
 			const types = _.clipboardData.types;


### PR DESCRIPTION
Fixes #236

The message input box (`#typebox`) doesn't handle IME composition events properly. When typing CJK characters (Chinese/Japanese/Korean), the `keyup` handler in `giveBox()` calls `boxupdate()` on every keystroke, which does `box.innerHTML = ""; box.append(html)` — this wipes the DOM and kills the active IME session. So the candidate window closes after every single keystroke and you can only input one character at a time.

Also, pressing Enter to confirm an IME candidate triggers `handleEnter()` in index.ts and sends the message prematurely.

The fix:
- Check `event.isComposing` at the top of all keydown/keyup handlers and bail out early
- Add a `compositionend` listener to run `boxupdate()` once after the IME finishes

Tested with fcitx5 Pinyin on Linux/Chromium. Should work for any IME on any platform since it's standard DOM API.