### PR TITLE
minor style adjustments

### DIFF
--- a/src/webpage/message.ts
+++ b/src/webpage/message.ts
@@ -859,7 +859,7 @@ class Message extends SnowFlake {
 			text.classList.add("commentrow", "flexttb");
 			if (combine) {
 				const username = document.createElement("span");
-				username.classList.add("username");
+				username.classList.add("username", "ellipsis");
 				this.author.bind(username, this.guild);
 				const membProm = Member.resolveMember(this.author, this.guild);
 				membProm.then((member) => {

--- a/src/webpage/style.css
+++ b/src/webpage/style.css
@@ -1109,7 +1109,7 @@ textarea {
 }
 .forumHead {
 	width: calc(100% - 12px);
-	background: #00000073;
+	background: var(--dock-bg);
 	padding: 6px;
 	margin: 6px;
 	box-sizing: border-box;
@@ -1196,7 +1196,7 @@ textarea {
 	color: var(--red);
 }
 .forumPostBody {
-	background: #00000075;
+	background: var(--secondary-bg);
 	margin: 4px 12px;
 	padding: 6px;
 	border-radius: 4px;
@@ -2274,6 +2274,10 @@ span.instanceStatus {
 	height: 0;
 	overflow: hidden;
 }
+#replybox:not(:empty) ~ #typediv .outerTypeBox {
+	border-top-right-radius: 0;
+	border-top-left-radius: 0;
+}
 #realbox {
 	padding: 0 16px 28px 16px;
 	position: relative;
@@ -2633,6 +2637,7 @@ span.instanceStatus {
 	max-width: 100%;
 }
 .timestamp {
+	flex: none;
 	margin-left: 6px;
 	font-size: 0.75em;
 	color: var(--primary-text-soft);


### PR DESCRIPTION
# Description
Very minor adjustments for mobile and light theme

-Truncates username to one line (for mobile)
--timestamp set to not flex so it won't wrap to make space for username

-Changed forum search bar/entries to use color variables so light theme users can see
--the forum search bar uses the same color as the other search bar for what it's worth

-Flattens the top corners of the typebox when the reply popup is there so there won't be tiny gaps on the sides