### PR TITLE
en.json improvement edits

### DIFF
--- a/translations/en.json
+++ b/translations/en.json
@@ -320,7 +320,7 @@
 		"description:": "Description:",
 		"disoveryTitle": "Guild discovery ($1 {{PLURAL:$1|entry|entries}})",
 		"editingTemplate": "Editing $1",
-		"emptytext": "You're in a weird situation, this guild has no channels!",
+		"emptytext": "How curious, this guild has no channels!?",
 		"emptytitle": "Weird spot",
 		"guilds": "Guilds",
 		"helpTips?": "Send helpful tips for your guild!",


### PR DESCRIPTION
# Description
Improving on text cues and feature descriptions, should also facilitate translations for some languages - only on the `en.json` file, translations to follow via translatewiki

# Related issues
talking with @MathMan05, potentially duplicating the setting description for permissions to have wording fit roles perms, per-channel role perms, per-channel per individual perms