### PR TITLE
Enforcing instance char limit for bio and usernames

### DIFF
--- a/src/webpage/bot.ts
+++ b/src/webpage/bot.ts
@@ -122,7 +122,7 @@ class Bot {
 			});
 			const bioBox = settingsLeft.addMDInput(I18n.bio(), (_) => {}, {
 				initText: bot.bio.rawString,
-				maxLength: this.localuser.instanceLimits.user.maxBio ?? 9999
+				maxLength: this.localuser.instanceLimits.user?.maxBio ?? 9999
 			});
 			bioBox.watchForChange((_) => {
 				newbio = _;

--- a/src/webpage/bot.ts
+++ b/src/webpage/bot.ts
@@ -122,6 +122,7 @@ class Bot {
 			});
 			const bioBox = settingsLeft.addMDInput(I18n.bio(), (_) => {}, {
 				initText: bot.bio.rawString,
+				maxLength: this.localuser.instanceLimits.user.maxBio ?? 9999
 			});
 			bioBox.watchForChange((_) => {
 				newbio = _;

--- a/src/webpage/channel.ts
+++ b/src/webpage/channel.ts
@@ -413,6 +413,7 @@ class Channel extends SnowFlake {
 			});
 			form.addTextInput(I18n.channel["name:"](), "name", {
 				initText: this.name,
+                maxLength: this.localuser.instanceLimits.channel?.maxName ?? 9999,
 			});
 			form.addMDInput(I18n.channel["topic:"](), "topic", {
 				initText: this.topic,

--- a/src/webpage/channel.ts
+++ b/src/webpage/channel.ts
@@ -416,6 +416,7 @@ class Channel extends SnowFlake {
 			});
 			form.addMDInput(I18n.channel["topic:"](), "topic", {
 				initText: this.topic,
+                maxLength: this.localuser.instanceLimits.channel?.maxTopic ?? 9999,
 			});
 			form.addImageInput(I18n.channel.icon(), "icon", {
 				initImg: this.icon ? this.iconUrl() : undefined,

--- a/src/webpage/direct.ts
+++ b/src/webpage/direct.ts
@@ -505,6 +505,7 @@ class Group extends Channel {
 		});
 		form.addTextInput(I18n.channel["name:"](), "name", {
 			initText: this.name === this.defaultName() ? "" : this.name,
+            maxLength: this.localuser.instanceLimits.channel?.maxName ?? 9999,
 		});
 		form.addImageInput(I18n.channel.icon(), "icon", {
 			initImg: this.icon ? this.iconUrl() : undefined,

--- a/src/webpage/member.ts
+++ b/src/webpage/member.ts
@@ -188,6 +188,7 @@ class Member extends SnowFlake {
 		);
 		form.addTextInput(I18n.member["nick:"](), "nick", {
 			initText: this.nick,
+            maxLength: this.localuser.instanceLimits.user?.maxUsername ?? 9999,
 		});
 		dio.show();
 	}
@@ -214,6 +215,7 @@ class Member extends SnowFlake {
 
 			const nicky = settingsLeft.addTextInput(I18n.member["nick:"](), () => {}, {
 				initText: this.nick || "",
+                maxLength: this.localuser.instanceLimits.user?.maxUsername ?? 9999,
 			});
 			nicky.watchForChange((_) => {
 				hypomember.nick = _;
@@ -294,6 +296,7 @@ class Member extends SnowFlake {
 			});
 			const bioBox = settingsLeft.addMDInput(I18n.bio(), (_) => {}, {
 				initText: this.bio,
+                maxLength: this.localuser.instanceLimits.user?.maxBio ?? 9999
 			});
 			bioBox.watchForChange((_) => {
 				newbio = _;

--- a/src/webpage/settings.ts
+++ b/src/webpage/settings.ts
@@ -1876,8 +1876,8 @@ class Form implements OptionsElement<object> {
 		return colorInput;
 	}
 
-	addMDInput(label: string, formName: string, {initText = "", required = false} = {}) {
-		const mdInput = this.options.addMDInput(label, (_) => {}, {initText});
+	addMDInput(label: string, formName: string, {initText = "", required = false, maxLength=9999} = {}) {
+		const mdInput = this.options.addMDInput(label, (_) => {}, {initText, maxLength});
 		this.names.set(formName, mdInput);
 		if (required) {
 			this.required.add(mdInput);

--- a/src/webpage/user.ts
+++ b/src/webpage/user.ts
@@ -640,6 +640,7 @@ class User extends SnowFlake {
 		);
 		form.addTextInput(I18n.member["nick:"](), "nickname", {
 			initText: this.nickname || "",
+            maxLength: this.localuser.instanceLimits.user?.maxUsername ?? 9999,
 		});
 		dio.show();
 	}

--- a/translations/en.json
+++ b/translations/en.json
@@ -484,6 +484,7 @@
 		"areYouSureDelete": "Are you sure you want to delete your account? If so enter the phrase $1",
 		"badCode": "Invalid code",
 		"badPassword": "Incorrect password",
+        "inputLengthLimit": "Length limit reached",
 		"botAvatar": "Bot avatar:",
 		"botInviteCreate": "Bot Invite Creator",
 		"botUsername": "Bot username:",


### PR DESCRIPTION
# Description
Heya
Enforcing char limit according to instance policy for bio and usernames
Char limit support has been added to TextInput and MDInput classes.
An error toast message is shown when limit is reached.

I'll appreciate to have a review as I'm not sure about the code organization.

Also maybe the same could be done for other text inputs although not mentioned in instance policy?

# Related issues
Issue #146 
