### PR TITLE
Make new guilds draggable

### DIFF
--- a/src/webpage/localuser.ts
+++ b/src/webpage/localuser.ts
@@ -835,7 +835,7 @@ class Localuser {
 						const guildy = new Guild(temp.d, this, this.user);
 						this.guilds.push(guildy);
 						this.guildids.set(guildy.id, guildy);
-						const divy = guildy.generateGuildIcon();
+						const divy = this.makeGuildIcon(guildy);
 						guildy.HTMLicon = divy;
 						(document.getElementById("servers") as HTMLDivElement).insertBefore(
 							divy,


### PR DESCRIPTION
# Description
Fixing a bug where new created/joined guilds were not made draggable.
Seems like the handleEvent function for GUILD_CREATE event was using the wrong function.

# Related issues
Issue #279 
