### PR TITLE
mobile sticker width + text baseline + theme colors

### DIFF
--- a/src/webpage/style.css
+++ b/src/webpage/style.css
@@ -768,6 +768,9 @@ textarea {
 ::-webkit-calendar-picker-indicator {
 	opacity: 1;
 }
+::placeholder {
+	color: color-mix(in srgb, var(--primary-text-soft), transparent);
+}
 :focus-visible {
 	outline: 2px solid var(--focus);
 	outline-offset: 0;


### PR DESCRIPTION
# Description
- on mobile, sticker will not exceed message width (height: auto is to preserve aspect ratio)
- adjusted vertical alignment of user info and reply text to visual baseline (icons centered)

Edits
- added unrelated fix for non-square pfps to not get stretched
- also matched the style of DMs to the existing channel styles so it works with all themes/matches expectations
- also adjusted colors on the gif picker to work with all themes/match sticker and emoji popups