### PR TITLE
hide gif/sticker/emoji when can't message

### DIFF
--- a/src/webpage/channel.ts
+++ b/src/webpage/channel.ts
@@ -2716,6 +2716,15 @@ class Channel extends SnowFlake {
 		(document.getElementById("upload") as HTMLElement).style.visibility = this.canMessage
 			? "visible"
 			: "hidden";
+		(document.getElementById("gifTB") as HTMLElement).style.visibility = this.canMessage
+			? "visible"
+			: "hidden";
+		(document.getElementById("stickerTB") as HTMLElement).style.visibility = this.canMessage
+			? "visible"
+			: "hidden";
+		(document.getElementById("emojiTB") as HTMLElement).style.visibility = this.canMessage
+			? "visible"
+			: "hidden";
 		(document.getElementById("typediv") as HTMLElement).style.visibility = "visible";
 		if (!mobile) {
 			(document.getElementById("typebox") as HTMLDivElement).focus();


### PR DESCRIPTION
# Description
Hides the gif/sticker/emoji buttons for channels where you cannot message. Same as the media upload button is now.
