### PR TITLE
mobile send + remove entirely not just hide

### DIFF
--- a/src/webpage/channel.ts
+++ b/src/webpage/channel.ts
@@ -2716,15 +2716,18 @@ class Channel extends SnowFlake {
 		(document.getElementById("upload") as HTMLElement).style.visibility = this.canMessage
 			? "visible"
 			: "hidden";
-		(document.getElementById("gifTB") as HTMLElement).style.visibility = this.canMessage
-			? "visible"
-			: "hidden";
-		(document.getElementById("stickerTB") as HTMLElement).style.visibility = this.canMessage
-			? "visible"
-			: "hidden";
-		(document.getElementById("emojiTB") as HTMLElement).style.visibility = this.canMessage
-			? "visible"
-			: "hidden";
+		(document.getElementById("gifTB") as HTMLElement).style.display = this.canMessage
+			? "block"
+			: "none";
+		(document.getElementById("stickerTB") as HTMLElement).style.display = this.canMessage
+			? "block"
+			: "none";
+		(document.getElementById("emojiTB") as HTMLElement).style.display = this.canMessage
+			? "block"
+			: "none";
+		(document.getElementById("mobileSend") as HTMLElement).style.display = this.canMessage
+			? "block"
+			: "none";
 		(document.getElementById("typediv") as HTMLElement).style.visibility = "visible";
 		if (!mobile) {
 			(document.getElementById("typebox") as HTMLDivElement).focus();


### PR DESCRIPTION
# Description
- I forgot to remove the mobile send button too, so now it's gone.
- Also changed to display: none (unlike the upload button, they should not take up space in the box when they're not there, so the "You can't send messages here" won't wrap on small screens)